### PR TITLE
Fix offset() to include the '_fn' parameter

### DIFF
--- a/openpyscad/base.py
+++ b/openpyscad/base.py
@@ -26,7 +26,7 @@ class MetaObject(type):
         'resize': ('resize', ('newsize', 'auto'), True),
         'mirror': ('mirror', ('__axis', ), True),
         'color': ('color', ('__color', 'a'), True),
-        'offset': ('offset', ('r', 'chamfer'), True),
+        'offset': ('offset', ('r', 'chamfer', '_fn'), True),
         'minkowski': ('minkowski', (), True),
         'hull': ('hull', (), True),
         'linear_extrude': ('linear_extrude', ('height', 'center',


### PR DESCRIPTION
The openscad offset() function also takes $fn. This fixes this issue.