### PR TITLE
Fix for !16 - Union, Intersection, etc cannot use linear_extrude

### DIFF
--- a/openpyscad/base.py
+++ b/openpyscad/base.py
@@ -172,6 +172,14 @@ class _BaseObject(with_metaclass(MetaObject, ModifierMixin, object)):
                 indent=INDENT * indent_level
             )
 
+    def _is_2d(self):
+        '''Defaults to False if no children, else
+        returns true if all children are 2D. 2D shapes should override and return True.'''
+        if len(self.children) == 0:
+            return False
+
+        return all([i._is_2d() for i in self.children])
+
     def _validate_append(self, obj):
         """Override if any validation in append operation is required.
         :param obj:

--- a/openpyscad/shapes_2d.py
+++ b/openpyscad/shapes_2d.py
@@ -6,7 +6,8 @@ __all__ = ['Circle', 'Square', 'Polygon', 'Text']
 
 
 class _Shape2dObject(_BaseObject):
-    pass
+    def _is_2d(self):
+        return True
 
 
 Shape2dObject = _Shape2dObject

--- a/openpyscad/transformations.py
+++ b/openpyscad/transformations.py
@@ -54,13 +54,13 @@ class Minkowski(_Transformation):
 
 class Linear_Extrude(_Transformation):
     def _validate_append(self, obj):
-        from .shapes_2d import Shape2dObject
-        if not isinstance(obj, (Shape2dObject, Transformation)):
-            raise TypeError('Appended object must be a instance of Shape2dObject or Transformation.')
+
+        if not isinstance(obj, base.BaseObject) or not obj._is_2d():
+            raise TypeError('Appended object must be a 2D shape.')
 
 
 class Rotate_Extrude(_Transformation):
     def _validate_append(self, obj):
-        from .shapes_2d import Shape2dObject
-        if not isinstance(obj, (Shape2dObject, Transformation)):
-            raise TypeError('Appended object must be a instance of Shape2dObject.')
+
+        if not isinstance(obj, base.BaseObject) or not obj._is_2d():
+            raise TypeError('Appended object must be a 2D shape.')

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -109,7 +109,7 @@ class TestBaseObject(unittest.TestCase):
         c1 = Cube(size=10)
         self.assertEqual(str(c1), "cube(size=10);\n")
 
-    def test_add(self):
+    def test_add_3d(self):
         o = Empty()
         c1 = Cube(10)
         self.assertTrue((o + c1).equals(c1))
@@ -123,7 +123,7 @@ class TestBaseObject(unittest.TestCase):
         self.assertTrue(u2.children[0].equals(c1))
         self.assertTrue(u2.children[1].equals(c2))
 
-    def test_sub(self):
+    def test_sub_3d(self):
         o = Empty()
         c1 = Cube(10)
         self.assertTrue((o - c1).equals(c1))
@@ -133,6 +133,34 @@ class TestBaseObject(unittest.TestCase):
         self.assertTrue(d1.children[0].equals(c1))
 
         c2 = Cube(20)
+        d2 = c1 - c2
+        self.assertTrue(d2.children[0].equals(c1))
+        self.assertTrue(d2.children[1].equals(c2))
+
+    def test_add_2d(self):
+        o = Empty()
+        c1 = Square(10)
+        self.assertTrue((o + c1).equals(c1))
+
+        u = Union()
+        u1 = u + c1
+        self.assertTrue(u1.children[0].equals(c1))
+
+        c2 = Square(20)
+        u2 = c1 + c2
+        self.assertTrue(u2.children[0].equals(c1))
+        self.assertTrue(u2.children[1].equals(c2))
+
+    def test_sub_2d(self):
+        o = Empty()
+        c1 = Square(10)
+        self.assertTrue((o - c1).equals(c1))
+
+        d = Difference()
+        d1 = d - c1
+        self.assertTrue(d1.children[0].equals(c1))
+
+        c2 = Square(20)
         d2 = c1 - c2
         self.assertTrue(d2.children[0].equals(c1))
         self.assertTrue(d2.children[1].equals(c2))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -270,3 +270,21 @@ class TestBaseObject(unittest.TestCase):
         sc = Import(os.path.join(os.path.dirname(os.path.abspath(__file__)),'..','example','example.stl'))
         osc = o + sc 
         self.assertTrue('example.stl' in osc.dumps())
+
+    def test_is_2d(self):
+        s1 = Square(10)
+        s2 = Square(20)
+        c1 = Cube(10)
+        c2 = Cube(20)
+
+        d1 = s1 - s2
+        self.assertTrue(d1._is_2d())
+
+        d2 = c1 - c2
+        self.assertFalse(d2._is_2d())
+
+        a1 = s1 + s2
+        self.assertTrue(a1._is_2d())
+
+        a2 = c1 + c2
+        self.assertFalse(a2._is_2d())

--- a/tests/test_custom2dshapes.py
+++ b/tests/test_custom2dshapes.py
@@ -12,3 +12,7 @@ class TestCustom2dShapes(unittest.TestCase):
         c = c2d.star(20, [6, 10])
         self.assertTrue(c.dumps().startswith("polygon(points=[[6.0, 0.0], [9.5"))
 
+    def test_is_2d(self):
+        triangle = c2d.regular_polygon(3, 10)
+        self.assertTrue(triangle._is_2d())
+

--- a/tests/test_custom3dshapes.py
+++ b/tests/test_custom3dshapes.py
@@ -7,3 +7,7 @@ class TestCustom3dShapes(unittest.TestCase):
     def test_dice(self):
         dice = c3d.dice(15)
         self.assertTrue(dice.dumps().startswith("mirror("))
+
+    def test_dice_is_2d(self):
+        dice = c3d.dice(15)
+        self.assertFalse(dice._is_2d())

--- a/tests/test_shape_3d.py
+++ b/tests/test_shape_3d.py
@@ -7,3 +7,8 @@ class TestCube(unittest.TestCase):
     def test_cube(self):
         c = Cube(10)
         self.assertEqual(c.dumps(), "cube(size=10);\n")
+
+    def test_is_2d(self):
+        c = Cube(10)
+
+        self.assertFalse(c._is_2d())


### PR DESCRIPTION
I am now extruding unions and intersections of 2d shapes.  I think this code embodies a better way to check weather the object can be extruded (assuming that all 2D objects should be extrudable).

Open to any suggestions or thoughts, I just want this fixed on the PyPi release XD